### PR TITLE
Add gauges for mobile, update query to include strategy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,43 +15,83 @@ if (isNaN(pollInterval)) {
 
 
 const metrics = {
-	first_contentful_paint: new Prometheus.Gauge({
-		name: 'pagespeed_first_contentful_paint_milliseconds',
+	desktop_first_contentful_paint: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_first_contentful_paint_milliseconds',
 		help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
 		labelNames: [ 'page' ]
 	}),
-	first_cpu_idle: new Prometheus.Gauge({
-		name: 'pagespeed_first_cpu_idle_milliseconds',
+	desktop_first_cpu_idle: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_first_cpu_idle_milliseconds',
 		help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
 		labelNames: [ 'page' ]
 	}),
-	interactive: new Prometheus.Gauge({
-		name: 'pagespeed_interactive_milliseconds',
+	desktop_interactive: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_interactive_milliseconds',
 		help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
 		labelNames: [ 'page' ]
 	}),
-	speed_index: new Prometheus.Gauge({
-		name: 'pagespeed_speed_index_seconds',
+	desktop_speed_index: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_speed_index_seconds',
 		help: "Speed Index, more info here: https://web.dev/speed-index",
 		labelNames: [ 'page' ]
 	}),
-	max_potential_fid: new Prometheus.Gauge({
-		name: 'pagespeed_max_potential_fid_seconds',
+	desktop_max_potential_fid: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_max_potential_fid_seconds',
 		help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
 		labelNames: [ 'page' ]
 	}),
-	first_meaningful_paint: new Prometheus.Gauge({
-		name: 'pagespeed_first_meaningful_paint_seconds',
+	desktop_first_meaningful_paint: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_first_meaningful_paint_seconds',
 		help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
 		labelNames: [ 'page' ]
 	}),
-	performance_score: new Prometheus.Gauge({
-		name: 'pagespeed_performance_score',
+	desktop_performance_score: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_performance_score',
 		help: "Performance Score",
 		labelNames: [ 'page' ]
 	}),
-	accessibility_score: new Prometheus.Gauge({
-		name: 'pagespeed_accessibility_score',
+	desktop_accessibility_score: new Prometheus.Gauge({
+		name: 'desktop_pagespeed_accessibility_score',
+		help: "Accessibility Score",
+		labelNames: [ 'page' ]
+	}),
+	mobile_first_contentful_paint: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_first_contentful_paint_milliseconds',
+		help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
+		labelNames: [ 'page' ]
+	}),
+	mobile_first_cpu_idle: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_first_cpu_idle_milliseconds',
+		help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
+		labelNames: [ 'page' ]
+	}),
+	mobile_interactive: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_interactive_milliseconds',
+		help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
+		labelNames: [ 'page' ]
+	}),
+	mobile_speed_index: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_speed_index_seconds',
+		help: "Speed Index, more info here: https://web.dev/speed-index",
+		labelNames: [ 'page' ]
+	}),
+	mobile_max_potential_fid: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_max_potential_fid_seconds',
+		help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
+		labelNames: [ 'page' ]
+	}),
+	mobile_first_meaningful_paint: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_first_meaningful_paint_seconds',
+		help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
+		labelNames: [ 'page' ]
+	}),
+	mobile_performance_score: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_performance_score',
+		help: "Performance Score",
+		labelNames: [ 'page' ]
+	}),
+	mobile_accessibility_score: new Prometheus.Gauge({
+		name: 'mobile_pagespeed_accessibility_score',
 		help: "Accessibility Score",
 		labelNames: [ 'page' ]
 	})
@@ -59,20 +99,36 @@ const metrics = {
 
 for (let page of pages) {
 	setInterval(async () => {
-		let data = await pagespeed(page, apiKey);
-		if (data != null) {
+		let desktopData = await pagespeed(page, apiKey, 'DESKTOP');
+		if (desktopData != null) {
 			try {
-				metrics.first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(data));
-				metrics.first_cpu_idle.set({ page }, dataextractor.first_cpu_idle(data));
-				metrics.interactive.set({ page }, dataextractor.interactive(data));
-				metrics.speed_index.set({ page }, dataextractor.speed_index(data));
-				metrics.max_potential_fid.set({ page }, dataextractor.max_potential_fid(data));
-				metrics.first_meaningful_paint.set({ page }, dataextractor.first_meaningful_paint(data));
-				metrics.performance_score.set({ page }, dataextractor.performance_score(data));
-				metrics.accessibility_score.set({ page }, dataextractor.accessibility_score(data));
+				metrics.desktop_first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(desktopData));
+				metrics.desktop_first_cpu_idle.set({ page }, dataextractor.first_cpu_idle(desktopData));
+				metrics.desktop_interactive.set({ page }, dataextractor.interactive(desktopData));
+				metrics.desktop_speed_index.set({ page }, dataextractor.speed_index(desktopData));
+				metrics.desktop_max_potential_fid.set({ page }, dataextractor.max_potential_fid(desktopData));
+				metrics.desktop_first_meaningful_paint.set({ page }, dataextractor.first_meaningful_paint(desktopData));
+				metrics.desktop_performance_score.set({ page }, dataextractor.performance_score(desktopData));
+				metrics.desktop_accessibility_score.set({ page }, dataextractor.accessibility_score(desktopData));
 			} catch (e) {
 				console.error(`data parsing failed, response dumped, url called: ${page}`);
-				fs.writeFileSync('response.json', data, { mode: 0o755 });
+				fs.writeFileSync('response.json', desktopData, { mode: 0o755 });
+			}
+		}
+		let mobileData = await pagespeed(page, apiKey, 'MOBILE');
+		if (mobileData != null) {
+			try {
+				metrics.mobile_first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(mobileData));
+				metrics.mobile_first_cpu_idle.set({ page }, dataextractor.first_cpu_idle(mobileData));
+				metrics.mobile_interactive.set({ page }, dataextractor.interactive(mobileData));
+				metrics.mobile_speed_index.set({ page }, dataextractor.speed_index(mobileData));
+				metrics.mobile_max_potential_fid.set({ page }, dataextractor.max_potential_fid(mobileData));
+				metrics.mobile_first_meaningful_paint.set({ page }, dataextractor.first_meaningful_paint(mobileData));
+				metrics.mobile_performance_score.set({ page }, dataextractor.performance_score(mobileData));
+				metrics.mobile_accessibility_score.set({ page }, dataextractor.accessibility_score(mobileData));
+			} catch (e) {
+				console.error(`data parsing failed, response dumped, url called: ${page}. Error: ${e.message}`);
+				fs.writeFileSync('response.json', mobileData, { mode: 0o755 });
 			}
 		}
 	}, pollInterval * 60 * 1000);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const express = require('express');
 const Prometheus = require('prom-client');
 const promMid = require('express-prometheus-middleware');
-const { viewports, getPagespeedInsights } = require('./pagespeed');
+const { strategies, getPagespeedInsights } = require('./pagespeed');
 const dataextractor = require('./dataextractor');
 
 const apiKey = process.env.APIKey;
@@ -101,25 +101,25 @@ const metrics = {
 	}
 };
 
-const pagespeedDataSets = {
-	desktop: viewports.DESKTOP,
-	mobile: viewports.MOBILE
+const pagespeedStrategies = {
+	desktop: strategies.DESKTOP,
+	mobile: strategies.MOBILE
 };
 
 for (let page of pages) {
-	for (const pagespeedDataSet in pagespeedDataSets) {
+	for (const strategy in pagespeedStrategies) {
 		setInterval(async () => {
-			let data = await getPagespeedInsights(page, apiKey, pagespeedDataSets[pagespeedDataSet]);
+			let data = await getPagespeedInsights(page, apiKey, pagespeedStrategies[strategy]);
 			if (data) {
 				try {
-					metrics[pagespeedDataSet].first_contentful_paint.set({page}, dataextractor.first_contentful_paint(data));
-					metrics[pagespeedDataSet].first_cpu_idle.set({page}, dataextractor.first_cpu_idle(data));
-					metrics[pagespeedDataSet].interactive.set({page}, dataextractor.interactive(data));
-					metrics[pagespeedDataSet].speed_index.set({page}, dataextractor.speed_index(data));
-					metrics[pagespeedDataSet].max_potential_fid.set({page}, dataextractor.max_potential_fid(data));
-					metrics[pagespeedDataSet].first_meaningful_paint.set({page}, dataextractor.first_meaningful_paint(data));
-					metrics[pagespeedDataSet].performance_score.set({page}, dataextractor.performance_score(data));
-					metrics[pagespeedDataSet].accessibility_score.set({page}, dataextractor.accessibility_score(data));
+					metrics[strategy].first_contentful_paint.set({page}, dataextractor.first_contentful_paint(data));
+					metrics[strategy].first_cpu_idle.set({page}, dataextractor.first_cpu_idle(data));
+					metrics[strategy].interactive.set({page}, dataextractor.interactive(data));
+					metrics[strategy].speed_index.set({page}, dataextractor.speed_index(data));
+					metrics[strategy].max_potential_fid.set({page}, dataextractor.max_potential_fid(data));
+					metrics[strategy].first_meaningful_paint.set({page}, dataextractor.first_meaningful_paint(data));
+					metrics[strategy].performance_score.set({page}, dataextractor.performance_score(data));
+					metrics[strategy].accessibility_score.set({page}, dataextractor.accessibility_score(data));
 				} catch (e) {
 					console.error(`data parsing failed, response dumped, url called: ${page}. Error: ${e.message}`);
 					fs.writeFileSync('response.json', data, {mode: 0o755});

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ for (let page of pages) {
 				metrics.performance_score.set({ page }, dataextractor.performance_score(desktopData));
 				metrics.accessibility_score.set({ page }, dataextractor.accessibility_score(desktopData));
 			} catch (e) {
-				console.error(`data parsing failed, response dumped, url called: ${page}`);
+				console.error(`data parsing failed, response dumped, url called: ${page}. Error: ${e.message}`);
 				fs.writeFileSync('response.json', desktopData, { mode: 0o755 });
 			}
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -2,141 +2,131 @@ const fs = require('fs');
 const express = require('express');
 const Prometheus = require('prom-client');
 const promMid = require('express-prometheus-middleware');
-const pagespeed = require('./pagespeed');
+const { viewports, getPagespeedInsights } = require('./pagespeed');
 const dataextractor = require('./dataextractor');
 
 const apiKey = process.env.APIKey;
 const pages = process.env.PAGES.split(',').map((page) => page.trim());
 const PORT = 3000;
-var pollInterval = parseInt(process.env.POLL_INTERVAL_MINS,10); //minutes
+let pollInterval = parseInt(process.env.POLL_INTERVAL_MINS, 10); //minutes
 if (isNaN(pollInterval)) {
 	pollInterval = 1;
 }
 
 
 const metrics = {
-	first_contentful_paint: new Prometheus.Gauge({
-		name: 'pagespeed_first_contentful_paint_milliseconds',
-		help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
-		labelNames: [ 'page' ]
-	}),
-	first_cpu_idle: new Prometheus.Gauge({
-		name: 'pagespeed_first_cpu_idle_milliseconds',
-		help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
-		labelNames: [ 'page' ]
-	}),
-	interactive: new Prometheus.Gauge({
-		name: 'pagespeed_interactive_milliseconds',
-		help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
-		labelNames: [ 'page' ]
-	}),
-	speed_index: new Prometheus.Gauge({
-		name: 'pagespeed_speed_index_seconds',
-		help: "Speed Index, more info here: https://web.dev/speed-index",
-		labelNames: [ 'page' ]
-	}),
-	max_potential_fid: new Prometheus.Gauge({
-		name: 'pagespeed_max_potential_fid_seconds',
-		help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
-		labelNames: [ 'page' ]
-	}),
-	first_meaningful_paint: new Prometheus.Gauge({
-		name: 'pagespeed_first_meaningful_paint_seconds',
-		help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
-		labelNames: [ 'page' ]
-	}),
-	performance_score: new Prometheus.Gauge({
-		name: 'pagespeed_performance_score',
-		help: "Performance Score",
-		labelNames: [ 'page' ]
-	}),
-	accessibility_score: new Prometheus.Gauge({
-		name: 'pagespeed_accessibility_score',
-		help: "Accessibility Score",
-		labelNames: [ 'page' ]
-	}),
-	mobile_first_contentful_paint: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_first_contentful_paint_milliseconds',
-		help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
-		labelNames: [ 'page' ]
-	}),
-	mobile_first_cpu_idle: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_first_cpu_idle_milliseconds',
-		help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
-		labelNames: [ 'page' ]
-	}),
-	mobile_interactive: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_interactive_milliseconds',
-		help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
-		labelNames: [ 'page' ]
-	}),
-	mobile_speed_index: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_speed_index_seconds',
-		help: "Speed Index, more info here: https://web.dev/speed-index",
-		labelNames: [ 'page' ]
-	}),
-	mobile_max_potential_fid: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_max_potential_fid_seconds',
-		help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
-		labelNames: [ 'page' ]
-	}),
-	mobile_first_meaningful_paint: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_first_meaningful_paint_seconds',
-		help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
-		labelNames: [ 'page' ]
-	}),
-	mobile_performance_score: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_performance_score',
-		help: "Performance Score",
-		labelNames: [ 'page' ]
-	}),
-	mobile_accessibility_score: new Prometheus.Gauge({
-		name: 'pagespeed_mobile_accessibility_score',
-		help: "Accessibility Score",
-		labelNames: [ 'page' ]
-	})
+	desktop: {
+		first_contentful_paint: new Prometheus.Gauge({
+			name: 'pagespeed_first_contentful_paint_milliseconds',
+			help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
+			labelNames: [ 'page' ]
+		}),
+		first_cpu_idle: new Prometheus.Gauge({
+			name: 'pagespeed_first_cpu_idle_milliseconds',
+			help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
+			labelNames: [ 'page' ]
+		}),
+		interactive: new Prometheus.Gauge({
+			name: 'pagespeed_interactive_milliseconds',
+			help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
+			labelNames: [ 'page' ]
+		}),
+		speed_index: new Prometheus.Gauge({
+			name: 'pagespeed_speed_index_seconds',
+			help: "Speed Index, more info here: https://web.dev/speed-index",
+			labelNames: [ 'page' ]
+		}),
+		max_potential_fid: new Prometheus.Gauge({
+			name: 'pagespeed_max_potential_fid_seconds',
+			help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
+			labelNames: [ 'page' ]
+		}),
+		first_meaningful_paint: new Prometheus.Gauge({
+			name: 'pagespeed_first_meaningful_paint_seconds',
+			help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
+			labelNames: [ 'page' ]
+		}),
+		performance_score: new Prometheus.Gauge({
+			name: 'pagespeed_performance_score',
+			help: "Performance Score",
+			labelNames: [ 'page' ]
+		}),
+		accessibility_score: new Prometheus.Gauge({
+			name: 'pagespeed_accessibility_score',
+			help: "Accessibility Score",
+			labelNames: [ 'page' ]
+		}),
+	},
+	mobile: {
+		first_contentful_paint: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_first_contentful_paint_milliseconds',
+			help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
+			labelNames: ['page']
+		}),
+		first_cpu_idle: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_first_cpu_idle_milliseconds',
+			help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
+			labelNames: ['page']
+		}),
+		interactive: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_interactive_milliseconds',
+			help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
+			labelNames: ['page']
+		}),
+		speed_index: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_speed_index_seconds',
+			help: "Speed Index, more info here: https://web.dev/speed-index",
+			labelNames: ['page']
+		}),
+		max_potential_fid: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_max_potential_fid_seconds',
+			help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
+			labelNames: ['page']
+		}),
+		first_meaningful_paint: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_first_meaningful_paint_seconds',
+			help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
+			labelNames: ['page']
+		}),
+		performance_score: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_performance_score',
+			help: "Performance Score",
+			labelNames: ['page']
+		}),
+		accessibility_score: new Prometheus.Gauge({
+			name: 'pagespeed_mobile_accessibility_score',
+			help: "Accessibility Score",
+			labelNames: ['page']
+		})
+	}
 };
 
-const viewports = {
-	DESKTOP: 'DESKTOP',
-	MOBILE: 'MOBILE'
-}
+const pagespeedDataSets = {
+	desktop: viewports.DESKTOP,
+	mobile: viewports.MOBILE
+};
 
 for (let page of pages) {
-	setInterval(async () => {
-		let desktopData = await pagespeed(page, apiKey, viewports.DESKTOP);
-		if (desktopData != null) {
-			try {
-				metrics.first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(desktopData));
-				metrics.first_cpu_idle.set({ page }, dataextractor.first_cpu_idle(desktopData));
-				metrics.interactive.set({ page }, dataextractor.interactive(desktopData));
-				metrics.speed_index.set({ page }, dataextractor.speed_index(desktopData));
-				metrics.max_potential_fid.set({ page }, dataextractor.max_potential_fid(desktopData));
-				metrics.first_meaningful_paint.set({ page }, dataextractor.first_meaningful_paint(desktopData));
-				metrics.performance_score.set({ page }, dataextractor.performance_score(desktopData));
-				metrics.accessibility_score.set({ page }, dataextractor.accessibility_score(desktopData));
-			} catch (e) {
-				console.error(`data parsing failed, response dumped, url called: ${page}. Error: ${e.message}`);
-				fs.writeFileSync('response.json', desktopData, { mode: 0o755 });
+	for (const pagespeedDataSet in pagespeedDataSets) {
+		setInterval(async () => {
+			let data = await getPagespeedInsights(page, apiKey, pagespeedDataSets[pagespeedDataSet]);
+			if (data) {
+				try {
+					metrics[pagespeedDataSet].first_contentful_paint.set({page}, dataextractor.first_contentful_paint(data));
+					metrics[pagespeedDataSet].first_cpu_idle.set({page}, dataextractor.first_cpu_idle(data));
+					metrics[pagespeedDataSet].interactive.set({page}, dataextractor.interactive(data));
+					metrics[pagespeedDataSet].speed_index.set({page}, dataextractor.speed_index(data));
+					metrics[pagespeedDataSet].max_potential_fid.set({page}, dataextractor.max_potential_fid(data));
+					metrics[pagespeedDataSet].first_meaningful_paint.set({page}, dataextractor.first_meaningful_paint(data));
+					metrics[pagespeedDataSet].performance_score.set({page}, dataextractor.performance_score(data));
+					metrics[pagespeedDataSet].accessibility_score.set({page}, dataextractor.accessibility_score(data));
+				} catch (e) {
+					console.error(`data parsing failed, response dumped, url called: ${page}. Error: ${e.message}`);
+					fs.writeFileSync('response.json', data, {mode: 0o755});
+				}
 			}
-		}
-		let mobileData = await pagespeed(page, apiKey, viewports.MOBILE);
-		if (mobileData != null) {
-			try {
-				metrics.mobile_first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(mobileData));
-				metrics.mobile_first_cpu_idle.set({ page }, dataextractor.first_cpu_idle(mobileData));
-				metrics.mobile_interactive.set({ page }, dataextractor.interactive(mobileData));
-				metrics.mobile_speed_index.set({ page }, dataextractor.speed_index(mobileData));
-				metrics.mobile_max_potential_fid.set({ page }, dataextractor.max_potential_fid(mobileData));
-				metrics.mobile_first_meaningful_paint.set({ page }, dataextractor.first_meaningful_paint(mobileData));
-				metrics.mobile_performance_score.set({ page }, dataextractor.performance_score(mobileData));
-				metrics.mobile_accessibility_score.set({ page }, dataextractor.accessibility_score(mobileData));
-			} catch (e) {
-				console.error(`data parsing failed, response dumped, url called: ${page}. Error: ${e.message}`);
-				fs.writeFileSync('response.json', mobileData, { mode: 0o755 });
-			}
-		}
-	}, pollInterval * 60 * 1000);
+		}, pollInterval * 60 * 1000);
+	}
 }
 
 const app = express();

--- a/src/index.js
+++ b/src/index.js
@@ -15,83 +15,83 @@ if (isNaN(pollInterval)) {
 
 
 const metrics = {
-	desktop_first_contentful_paint: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_first_contentful_paint_milliseconds',
+	first_contentful_paint: new Prometheus.Gauge({
+		name: 'pagespeed_first_contentful_paint_milliseconds',
 		help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
 		labelNames: [ 'page' ]
 	}),
-	desktop_first_cpu_idle: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_first_cpu_idle_milliseconds',
+	first_cpu_idle: new Prometheus.Gauge({
+		name: 'pagespeed_first_cpu_idle_milliseconds',
 		help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
 		labelNames: [ 'page' ]
 	}),
-	desktop_interactive: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_interactive_milliseconds',
+	interactive: new Prometheus.Gauge({
+		name: 'pagespeed_interactive_milliseconds',
 		help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
 		labelNames: [ 'page' ]
 	}),
-	desktop_speed_index: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_speed_index_seconds',
+	speed_index: new Prometheus.Gauge({
+		name: 'pagespeed_speed_index_seconds',
 		help: "Speed Index, more info here: https://web.dev/speed-index",
 		labelNames: [ 'page' ]
 	}),
-	desktop_max_potential_fid: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_max_potential_fid_seconds',
+	max_potential_fid: new Prometheus.Gauge({
+		name: 'pagespeed_max_potential_fid_seconds',
 		help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
 		labelNames: [ 'page' ]
 	}),
-	desktop_first_meaningful_paint: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_first_meaningful_paint_seconds',
+	first_meaningful_paint: new Prometheus.Gauge({
+		name: 'pagespeed_first_meaningful_paint_seconds',
 		help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
 		labelNames: [ 'page' ]
 	}),
-	desktop_performance_score: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_performance_score',
+	performance_score: new Prometheus.Gauge({
+		name: 'pagespeed_performance_score',
 		help: "Performance Score",
 		labelNames: [ 'page' ]
 	}),
-	desktop_accessibility_score: new Prometheus.Gauge({
-		name: 'desktop_pagespeed_accessibility_score',
+	accessibility_score: new Prometheus.Gauge({
+		name: 'pagespeed_accessibility_score',
 		help: "Accessibility Score",
 		labelNames: [ 'page' ]
 	}),
 	mobile_first_contentful_paint: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_first_contentful_paint_milliseconds',
+		name: 'pagespeed_mobile_first_contentful_paint_milliseconds',
 		help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
 		labelNames: [ 'page' ]
 	}),
 	mobile_first_cpu_idle: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_first_cpu_idle_milliseconds',
+		name: 'pagespeed_mobile_first_cpu_idle_milliseconds',
 		help: "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.",
 		labelNames: [ 'page' ]
 	}),
 	mobile_interactive: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_interactive_milliseconds',
+		name: 'pagespeed_mobile_interactive_milliseconds',
 		help: "Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.",
 		labelNames: [ 'page' ]
 	}),
 	mobile_speed_index: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_speed_index_seconds',
+		name: 'pagespeed_mobile_speed_index_seconds',
 		help: "Speed Index, more info here: https://web.dev/speed-index",
 		labelNames: [ 'page' ]
 	}),
 	mobile_max_potential_fid: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_max_potential_fid_seconds',
+		name: 'pagespeed_mobile_max_potential_fid_seconds',
 		help: "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay",
 		labelNames: [ 'page' ]
 	}),
 	mobile_first_meaningful_paint: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_first_meaningful_paint_seconds',
+		name: 'pagespeed_mobile_first_meaningful_paint_seconds',
 		help: "First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint",
 		labelNames: [ 'page' ]
 	}),
 	mobile_performance_score: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_performance_score',
+		name: 'pagespeed_mobile_performance_score',
 		help: "Performance Score",
 		labelNames: [ 'page' ]
 	}),
 	mobile_accessibility_score: new Prometheus.Gauge({
-		name: 'mobile_pagespeed_accessibility_score',
+		name: 'pagespeed_mobile_accessibility_score',
 		help: "Accessibility Score",
 		labelNames: [ 'page' ]
 	})
@@ -102,14 +102,14 @@ for (let page of pages) {
 		let desktopData = await pagespeed(page, apiKey, 'DESKTOP');
 		if (desktopData != null) {
 			try {
-				metrics.desktop_first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(desktopData));
-				metrics.desktop_first_cpu_idle.set({ page }, dataextractor.first_cpu_idle(desktopData));
-				metrics.desktop_interactive.set({ page }, dataextractor.interactive(desktopData));
-				metrics.desktop_speed_index.set({ page }, dataextractor.speed_index(desktopData));
-				metrics.desktop_max_potential_fid.set({ page }, dataextractor.max_potential_fid(desktopData));
-				metrics.desktop_first_meaningful_paint.set({ page }, dataextractor.first_meaningful_paint(desktopData));
-				metrics.desktop_performance_score.set({ page }, dataextractor.performance_score(desktopData));
-				metrics.desktop_accessibility_score.set({ page }, dataextractor.accessibility_score(desktopData));
+				metrics.first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(desktopData));
+				metrics.first_cpu_idle.set({ page }, dataextractor.first_cpu_idle(desktopData));
+				metrics.interactive.set({ page }, dataextractor.interactive(desktopData));
+				metrics.speed_index.set({ page }, dataextractor.speed_index(desktopData));
+				metrics.max_potential_fid.set({ page }, dataextractor.max_potential_fid(desktopData));
+				metrics.first_meaningful_paint.set({ page }, dataextractor.first_meaningful_paint(desktopData));
+				metrics.performance_score.set({ page }, dataextractor.performance_score(desktopData));
+				metrics.accessibility_score.set({ page }, dataextractor.accessibility_score(desktopData));
 			} catch (e) {
 				console.error(`data parsing failed, response dumped, url called: ${page}`);
 				fs.writeFileSync('response.json', desktopData, { mode: 0o755 });

--- a/src/index.js
+++ b/src/index.js
@@ -97,9 +97,14 @@ const metrics = {
 	})
 };
 
+const viewports = {
+	DESKTOP: 'DESKTOP',
+	MOBILE: 'MOBILE'
+}
+
 for (let page of pages) {
 	setInterval(async () => {
-		let desktopData = await pagespeed(page, apiKey, 'DESKTOP');
+		let desktopData = await pagespeed(page, apiKey, viewports.DESKTOP);
 		if (desktopData != null) {
 			try {
 				metrics.first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(desktopData));
@@ -115,7 +120,7 @@ for (let page of pages) {
 				fs.writeFileSync('response.json', desktopData, { mode: 0o755 });
 			}
 		}
-		let mobileData = await pagespeed(page, apiKey, 'MOBILE');
+		let mobileData = await pagespeed(page, apiKey, viewports.MOBILE);
 		if (mobileData != null) {
 			try {
 				metrics.mobile_first_contentful_paint.set({ page }, dataextractor.first_contentful_paint(mobileData));

--- a/src/pagespeed.js
+++ b/src/pagespeed.js
@@ -1,13 +1,22 @@
 const axios = require('axios');
 
-module.exports = async function(page, apiKey, viewport) {
+const viewports = {
+	DESKTOP: 'DESKTOP',
+	MOBILE: 'MOBILE'
+};
+
+const getPagespeedInsights = async (page, apiKey, viewport) => {
 	let url = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=${page}&key=${apiKey}&category=PERFORMANCE&category=ACCESSIBILITY&strategy=${viewport}`;
 	try {
 		const response = await axios.get(url);
-		const data = response.data;
-		return data;
+		return response.data;
 	} catch (error) {
 		console.error(`Error fetching ${page} - ${error}`)
 		return null;
 	}
 };
+
+module.exports = {
+	viewports,
+	getPagespeedInsights
+}

--- a/src/pagespeed.js
+++ b/src/pagespeed.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 
-module.exports = async function(page, apiKey) {
-	let url = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=${page}&key=${apiKey}&category=PERFORMANCE&category=ACCESSIBILITY`;
+module.exports = async function(page, apiKey, viewport) {
+	let url = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=${page}&key=${apiKey}&category=PERFORMANCE&category=ACCESSIBILITY&strategy=${viewport}`;
 	try {
 		const response = await axios.get(url);
 		const data = response.data;

--- a/src/pagespeed.js
+++ b/src/pagespeed.js
@@ -1,12 +1,12 @@
 const axios = require('axios');
 
-const viewports = {
+const strategies = {
 	DESKTOP: 'DESKTOP',
 	MOBILE: 'MOBILE'
 };
 
-const getPagespeedInsights = async (page, apiKey, viewport) => {
-	let url = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=${page}&key=${apiKey}&category=PERFORMANCE&category=ACCESSIBILITY&strategy=${viewport}`;
+const getPagespeedInsights = async (page, apiKey, strategy) => {
+	let url = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=${page}&key=${apiKey}&category=PERFORMANCE&category=ACCESSIBILITY&strategy=${strategy}`;
 	try {
 		const response = await axios.get(url);
 		return response.data;
@@ -17,6 +17,6 @@ const getPagespeedInsights = async (page, apiKey, viewport) => {
 };
 
 module.exports = {
-	viewports,
+	strategies,
 	getPagespeedInsights
 }


### PR DESCRIPTION
Updated query to include the strategy parameter so can query for both mobile and desktop results.
Added additional gauges to the index page to display the additional mobile results.

Fixes https://github.com/Tom-Davidson/pagespeedinsights-collector/issues/6