### PR TITLE
Hotfix: Multiple Pages not collecting metrics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,51 +19,51 @@ const pagespeedStrategies = {
 	mobile: strategies.MOBILE
 };
 
-for (const page of pages) {
-	for (const strategy in pagespeedStrategies) {
-		const metrics = {
-			[`first_contentful_paint_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_first_contentful_paint_milliseconds_${strategy}`,
-				help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
-				labelNames: [ 'page' ]
-			}),
-			[`first_cpu_idle_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_first_cpu_idle_milliseconds_${strategy}`,
-				help: `First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.`,
-				labelNames: [ 'page' ]
-			}),
-			[`interactive_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_interactive_milliseconds_${strategy}`,
-				help: `Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.`,
-				labelNames: [ 'page' ]
-			}),
-			[`speed_index_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_speed_index_seconds_${strategy}`,
-				help: `Speed Index, more info here: https://web.dev/speed-index`,
-				labelNames: [ 'page' ]
-			}),
-			[`max_potential_fid_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_max_potential_fid_seconds_${strategy}`,
-				help: `The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay`,
-				labelNames: [ 'page' ]
-			}),
-			[`first_meaningful_paint_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_first_meaningful_paint_seconds_${strategy}`,
-				help: `First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint`,
-				labelNames: [ 'page' ]
-			}),
-			[`performance_score_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_performance_score_${strategy}`,
-				help: `Performance Score`,
-				labelNames: [ 'page' ]
-			}),
-			[`accessibility_score_${strategy}`]: new Prometheus.Gauge({
-				name: `pagespeed_accessibility_score_${strategy}`,
-				help: `Accessibility Score`,
-				labelNames: [ 'page' ]
-			}),
-		}
+for (const strategy in pagespeedStrategies) {
+	const metrics = {
+		[`first_contentful_paint_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_first_contentful_paint_milliseconds_${strategy}`,
+			help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
+			labelNames: ['page']
+		}),
+		[`first_cpu_idle_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_first_cpu_idle_milliseconds_${strategy}`,
+			help: `First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.`,
+			labelNames: ['page']
+		}),
+		[`interactive_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_interactive_milliseconds_${strategy}`,
+			help: `Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.`,
+			labelNames: ['page']
+		}),
+		[`speed_index_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_speed_index_seconds_${strategy}`,
+			help: `Speed Index, more info here: https://web.dev/speed-index`,
+			labelNames: ['page']
+		}),
+		[`max_potential_fid_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_max_potential_fid_seconds_${strategy}`,
+			help: `The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay`,
+			labelNames: ['page']
+		}),
+		[`first_meaningful_paint_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_first_meaningful_paint_seconds_${strategy}`,
+			help: `First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint`,
+			labelNames: ['page']
+		}),
+		[`performance_score_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_performance_score_${strategy}`,
+			help: `Performance Score`,
+			labelNames: ['page']
+		}),
+		[`accessibility_score_${strategy}`]: new Prometheus.Gauge({
+			name: `pagespeed_accessibility_score_${strategy}`,
+			help: `Accessibility Score`,
+			labelNames: ['page']
+		}),
+	}
 
+	for (const page of pages) {
 		setInterval(async () => {
 			let data = await getPagespeedInsights(page, apiKey, pagespeedStrategies[strategy]);
 			if (data != null) {


### PR DESCRIPTION
Fixed a bug which prevented multiple pages from having their metrics collected.

Tested with multiple pages and verified with @sbthompson 