### PR TITLE
Remove first cpu idle metric

### DIFF
--- a/src/dataextractor.js
+++ b/src/dataextractor.js
@@ -15,9 +15,6 @@ const collect_numeric_from_audits = (data, key) => {
 const first_contentful_paint = (data) => {
 	return collect_numeric_from_audits(data, 'first-contentful-paint');
 };
-const first_cpu_idle = (data) => {
-	return collect_numeric_from_audits(data, 'first-cpu-idle');
-};
 const interactive = (data) => {
 	return collect_numeric_from_audits(data, 'interactive');
 };
@@ -55,7 +52,6 @@ const accessibility_score = (data) => {
 
 module.exports = {
 	first_contentful_paint,
-	first_cpu_idle,
 	interactive,
 	speed_index,
 	max_potential_fid,

--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,6 @@ for (const strategy in pagespeedStrategies) {
 			help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
 			labelNames: ['page']
 		}),
-		[`first_cpu_idle_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_first_cpu_idle_milliseconds_${strategy}`,
-			help: `First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  https://web.dev/first-cpu-idle.`,
-			labelNames: ['page']
-		}),
 		[`interactive_${strategy}`]: new Prometheus.Gauge({
 			name: `pagespeed_interactive_milliseconds_${strategy}`,
 			help: `Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.`,
@@ -69,7 +64,6 @@ for (const strategy in pagespeedStrategies) {
 			if (data != null) {
 				try {
 					metrics[`first_contentful_paint_${strategy}`].set({page}, dataextractor.first_contentful_paint(data));
-					metrics[`first_cpu_idle_${strategy}`].set({page}, dataextractor.first_cpu_idle(data));
 					metrics[`interactive_${strategy}`].set({page}, dataextractor.interactive(data));
 					metrics[`speed_index_${strategy}`].set({page}, dataextractor.speed_index(data));
 					metrics[`max_potential_fid_${strategy}`].set({page}, dataextractor.max_potential_fid(data));

--- a/tests/dataextractor.test.js
+++ b/tests/dataextractor.test.js
@@ -9,10 +9,6 @@ test('dataextractor.first_contentful_paint with bad data', () => {
 	const fcp = dataextractor.first_contentful_paint(undefined);
 	expect(fcp).toBe(undefined);
 });
-test('dataextractor.first_cpu_idle', () => {
-	const fci = dataextractor.first_cpu_idle(data);
-	expect(fci).toBe(2979);
-});
 test('dataextractor.interactive', () => {
 	const tti = dataextractor.interactive(data);
 	expect(tti).toBe(3137.5);


### PR DESCRIPTION
Removed reference to metric which has been removed from lighthouse v8.

This change is simply to fix the process.  As a next step it would be good to make it handle this situation without failing all metric collection.