### PR TITLE
Prometheus metric names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,57 +19,58 @@ const pagespeedStrategies = {
 	mobile: strategies.MOBILE
 };
 
-for (const strategy in pagespeedStrategies) {
-	const metrics = {
-		[`first_contentful_paint_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_first_contentful_paint_milliseconds_${strategy}`,
-			help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
-			labelNames: ['page']
-		}),
-		[`interactive_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_interactive_milliseconds_${strategy}`,
-			help: `Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.`,
-			labelNames: ['page']
-		}),
-		[`speed_index_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_speed_index_seconds_${strategy}`,
-			help: `Speed Index, more info here: https://web.dev/speed-index`,
-			labelNames: ['page']
-		}),
-		[`max_potential_fid_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_max_potential_fid_seconds_${strategy}`,
-			help: `The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay`,
-			labelNames: ['page']
-		}),
-		[`first_meaningful_paint_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_first_meaningful_paint_seconds_${strategy}`,
-			help: `First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint`,
-			labelNames: ['page']
-		}),
-		[`performance_score_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_performance_score_${strategy}`,
-			help: `Performance Score`,
-			labelNames: ['page']
-		}),
-		[`accessibility_score_${strategy}`]: new Prometheus.Gauge({
-			name: `pagespeed_accessibility_score_${strategy}`,
-			help: `Accessibility Score`,
-			labelNames: ['page']
-		}),
-	}
+const metrics = {
+	[`first_contentful_paint`]: new Prometheus.Gauge({
+		name: `pagespeed_first_contentful_paint_milliseconds`,
+		help: 'Time to first contentful paint, more info here: https://web.dev/first-contentful-paint/',
+		labelNames: ['page','strategy']
+	}),
+	[`interactive`]: new Prometheus.Gauge({
+		name: `pagespeed_interactive_milliseconds`,
+		help: `Time to interactive is the amount of time it takes for the page to become fully interactive. https://web.dev/interactive.`,
+		labelNames: ['page','strategy']
+	}),
+	[`speed_index`]: new Prometheus.Gauge({
+		name: `pagespeed_speed_index_seconds`,
+		help: `Speed Index, more info here: https://web.dev/speed-index`,
+		labelNames: ['page','strategy']
+	}),
+	[`max_potential_fid`]: new Prometheus.Gauge({
+		name: `pagespeed_max_potential_fid_seconds`,
+		help: `The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. https://developers.google.com/web/updates/2018/05/first-input-delay`,
+		labelNames: ['page','strategy']
+	}),
+	[`first_meaningful_paint`]: new Prometheus.Gauge({
+		name: `pagespeed_first_meaningful_paint_seconds`,
+		help: `First Meaningful Paint measures when the primary content of a page is visible. https://web.dev/first-meaningful-paint`,
+		labelNames: ['page','strategy']
+	}),
+	[`performance_score`]: new Prometheus.Gauge({
+		name: `pagespeed_performance_score`,
+		help: `Performance Score`,
+		labelNames: ['page','strategy']
+	}),
+	[`accessibility_score`]: new Prometheus.Gauge({
+		name: `pagespeed_accessibility_score`,
+		help: `Accessibility Score`,
+		labelNames: ['page','strategy']
+	}),
+}
 
+for (const strategy in pagespeedStrategies) {
 	for (const page of pages) {
 		setInterval(async () => {
 			let data = await getPagespeedInsights(page, apiKey, pagespeedStrategies[strategy]);
-			if (data != null) {
+			if (data != null) {														
 				try {
-					metrics[`first_contentful_paint_${strategy}`].set({page}, dataextractor.first_contentful_paint(data));
-					metrics[`interactive_${strategy}`].set({page}, dataextractor.interactive(data));
-					metrics[`speed_index_${strategy}`].set({page}, dataextractor.speed_index(data));
-					metrics[`max_potential_fid_${strategy}`].set({page}, dataextractor.max_potential_fid(data));
-					metrics[`first_meaningful_paint_${strategy}`].set({page}, dataextractor.first_meaningful_paint(data));
-					metrics[`performance_score_${strategy}`].set({page}, dataextractor.performance_score(data));
-					metrics[`accessibility_score_${strategy}`].set({page}, dataextractor.accessibility_score(data));
+					let labels = {page, strategy};
+					metrics[`first_contentful_paint`].set(labels, dataextractor.first_contentful_paint(data));
+					metrics[`interactive`].set(labels, dataextractor.interactive(data));
+					metrics[`speed_index`].set(labels, dataextractor.speed_index(data));
+					metrics[`max_potential_fid`].set(labels, dataextractor.max_potential_fid(data));
+					metrics[`first_meaningful_paint`].set(labels, dataextractor.first_meaningful_paint(data));
+					metrics[`performance_score`].set(labels, dataextractor.performance_score(data));
+					metrics[`accessibility_score`].set(labels, dataextractor.accessibility_score(data));
 				} catch (e) {
 					console.log(e);
 					console.error(`data parsing failed, response dumped, url called: ${page}`);


### PR DESCRIPTION
Change to make desktop/mobile metrics available with property labels in addition to existing format to maintain backwards compatibility.